### PR TITLE
rewrite wriestore::flush()

### DIFF
--- a/src/store.rs
+++ b/src/store.rs
@@ -181,11 +181,7 @@ impl WriteStore for DBStore {
     }
 
     fn flush(&self) {
-        let mut opts = rocksdb::WriteOptions::new();
-        opts.set_sync(true);
-        opts.disable_wal(false);
-        let empty = rocksdb::WriteBatch::default();
-        self.db.write_opt(empty, &opts).unwrap();
+        self.db.flush().unwrap();
     }
 }
 


### PR DESCRIPTION
forces a flush of memtables to sst files